### PR TITLE
Feature/logging sample

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -486,6 +486,43 @@
         "@dazn/lambda-powertools-correlation-ids": "^1.28.1"
       }
     },
+    "@dazn/lambda-powertools-middleware-correlation-ids": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-middleware-correlation-ids/-/lambda-powertools-middleware-correlation-ids-1.29.0.tgz",
+      "integrity": "sha512-kXOOKzEMKz6nYHUQo2GUvTqnQeXo1U6/RI87xUjSeztcjHaDZ0Jw6plUepZD+YawjfsVIrHKfnZrlN909utttA==",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "^1.28.1",
+        "@dazn/lambda-powertools-logger": "^1.28.1"
+      }
+    },
+    "@dazn/lambda-powertools-middleware-log-timeout": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-middleware-log-timeout/-/lambda-powertools-middleware-log-timeout-1.29.0.tgz",
+      "integrity": "sha512-BJv3DQdcuOCBfp93cFv3LgCcCBhwh4s8COmw4x+c3cEdkY6zajo9tHAikFea8Fv9ShDXAcUgnPpkv8EFMbAH+w==",
+      "requires": {
+        "@dazn/lambda-powertools-logger": "^1.28.1"
+      }
+    },
+    "@dazn/lambda-powertools-middleware-sample-logging": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-middleware-sample-logging/-/lambda-powertools-middleware-sample-logging-1.29.0.tgz",
+      "integrity": "sha512-VHe3bSw0ch5Ql5tA3XvCta8db1Nr6NaSJ0Oj2oqQU+F15WJfqPD+reeKMgj3F1z8lJqXWAea3aD4nQT0PCTt6Q==",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "^1.28.1",
+        "@dazn/lambda-powertools-logger": "^1.28.1"
+      }
+    },
+    "@dazn/lambda-powertools-pattern-basic": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-pattern-basic/-/lambda-powertools-pattern-basic-1.29.0.tgz",
+      "integrity": "sha512-HYmu9eKVRYNu5Q2CYuOl3UmBMAfpHzvNJFRdR8f8F5DJLktsexapk1sDjZZq4bP1ZmduuSbG/mUN9nmtkCRWYw==",
+      "requires": {
+        "@dazn/lambda-powertools-middleware-correlation-ids": "^1.29.0",
+        "@dazn/lambda-powertools-middleware-log-timeout": "^1.29.0",
+        "@dazn/lambda-powertools-middleware-sample-logging": "^1.29.0",
+        "@middy/core": "^2.1.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@dazn/lambda-powertools-logger": "^1.28.1",
+    "@dazn/lambda-powertools-pattern-basic": "^1.29.0",
     "@middy/core": "^2.5.1",
     "@middy/ssm": "^2.5.1",
     "aws4": "^1.11.0",

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,6 +16,7 @@ provider:
           - .execute-api.${self:provider.region}.amazonaws.com/${self:custom.stage}
     SERVICE_NAME: ${self:service}
     LOG_LEVEL: ${self:custom.logLevel.${self:custom.stage}, self:custom.logLevel.default}
+    SAMPLE_DEBUG_LOG_RATE: 0.1
   eventBridge:
     useCloudFormation: true
 

--- a/src/functions/get-index.js
+++ b/src/functions/get-index.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const Log = require('@dazn/lambda-powertools-logger');
+const wrap = require('@dazn/lambda-powertools-pattern-basic');
 const Mustache = require('mustache');
 const http = require('axios');
 const aws4 = require('aws4');
@@ -44,7 +45,7 @@ const getRestaurants = async () => {
 };
 
 // eslint-disable-next-line no-unused-vars
-module.exports.handler = async (event, context) => {
+module.exports.handler = wrap(async (event, context) => {
   const restaurants = await getRestaurants();
   Log.debug('got restaurants', { count: restaurants.length });
 
@@ -71,4 +72,4 @@ module.exports.handler = async (event, context) => {
   };
 
   return response;
-};
+});

--- a/src/functions/get-restaurants.js
+++ b/src/functions/get-restaurants.js
@@ -1,7 +1,7 @@
 const DynamoDB = require('aws-sdk/clients/dynamodb');
-const middy = require('@middy/core');
 const ssm = require('@middy/ssm');
 const Log = require('@dazn/lambda-powertools-logger');
+const wrap = require('@dazn/lambda-powertools-pattern-basic');
 
 const DocumentClient = new DynamoDB.DocumentClient();
 
@@ -28,7 +28,7 @@ const getRestaurants = async limit => {
 };
 
 // eslint-disable-next-line no-unused-vars
-module.exports.handler = middy(async (event, context) => {
+module.exports.handler = wrap(async (event, context) => {
   const restaurants = await getRestaurants(context.config.defaultResults);
 
   const response = {

--- a/src/functions/notify-restaurant.js
+++ b/src/functions/notify-restaurant.js
@@ -1,6 +1,7 @@
 const EventBridge = require('aws-sdk/clients/eventbridge');
 const SNS = require('aws-sdk/clients/sns');
 const Log = require('@dazn/lambda-powertools-logger');
+const wrap = require('@dazn/lambda-powertools-pattern-basic');
 
 const eventBridge = new EventBridge();
 const sns = new SNS();
@@ -8,7 +9,7 @@ const sns = new SNS();
 const { BUS_NAME: busName, RESTAURANT_NOTIFICATION_TOPIC: topicArn } =
   process.env;
 
-module.exports.handler = async event => {
+module.exports.handler = wrap(async event => {
   const order = event.detail;
 
   const snsRequest = {
@@ -46,4 +47,4 @@ module.exports.handler = async event => {
     orderId,
     restaurantName,
   });
-};
+});

--- a/src/functions/place-order.js
+++ b/src/functions/place-order.js
@@ -1,12 +1,13 @@
 const EventBridge = require('aws-sdk/clients/eventbridge');
 const Log = require('@dazn/lambda-powertools-logger');
+const wrap = require('@dazn/lambda-powertools-pattern-basic');
 
 const eventBridge = new EventBridge();
 const chance = require('chance').Chance();
 
 const { BUS_NAME } = process.env;
 
-module.exports.handler = async event => {
+module.exports.handler = wrap(async event => {
   const { restaurantName } = JSON.parse(event.body);
 
   const orderId = chance.guid();
@@ -40,4 +41,4 @@ module.exports.handler = async event => {
   };
 
   return response;
-};
+});

--- a/src/functions/search-restaurants.js
+++ b/src/functions/search-restaurants.js
@@ -1,7 +1,7 @@
 const DynamoDB = require('aws-sdk/clients/dynamodb');
-const middy = require('@middy/core');
 const ssm = require('@middy/ssm');
 const Log = require('@dazn/lambda-powertools-logger');
+const wrap = require('@dazn/lambda-powertools-pattern-basic');
 
 const DocumentClient = new DynamoDB.DocumentClient();
 
@@ -33,7 +33,7 @@ const findRestaurantsByTheme = async (theme, limit) => {
 };
 
 // eslint-disable-next-line no-unused-vars
-module.exports.handler = middy(async (event, context) => {
+module.exports.handler = wrap(async (event, context) => {
   const request = JSON.parse(event.body);
   const { theme } = request;
   const restaurants = await findRestaurantsByTheme(


### PR DESCRIPTION
Enable logging sample allows that ~10% of the logs of DEBUG level are pushed to production. That makes it easier to track errors in production, but also avoids high costs with AWS CloudWatch Logs.