### PR TITLE
infra: powertune get-restaurants and get-index Lambdas

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -58,6 +58,7 @@ custom:
 functions:
   get-index:
     handler: src/functions/get-index.handler
+    memorySize: 128
     environment:
       RESTAURANTS_API:
         Fn::Join:
@@ -84,6 +85,7 @@ functions:
         Resource: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ApiGatewayRestApi}/${self:custom.stage}/GET/restaurants
   get-restaurants:
     handler: src/functions/get-restaurants.handler
+    memorySize: 512
     events:
       - http:
           path: /restaurants


### PR DESCRIPTION
Increase memory size of **get-restaurants** to 512MB and **get-index** to 128MB. Those metrics were extracted from insights of the Lumigo CLI powertune-lambda module.